### PR TITLE
feat(): switch to injected FrontierSharpHttpClient

### DIFF
--- a/src/FrontierSharp.Tests/WorldApi/WorldApiClientTests.cs
+++ b/src/FrontierSharp.Tests/WorldApi/WorldApiClientTests.cs
@@ -94,8 +94,7 @@ public class WorldApiClientTests {
     public async Task GetTypesPage_ShouldReturnTypes_WhenResponseIsValid() {
         // Arrange
         var factory = SubstitutableHttpClientFactory.CreateWithPayload(ValidResponse);
-        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
-        var client = new WorldApiClient(httpClient);
+        var client = CreateWorldApiClient(factory);
 
         // Act
         var result = await client.GetTypesPage();
@@ -110,8 +109,7 @@ public class WorldApiClientTests {
     public async Task GetTypesPage_ShouldReturnFailure_WhenInnerCallFails() {
         // Arrange
         var factory = SubstitutableHttpClientFactory.CreateInternalServerError();
-        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
-        var client = new WorldApiClient(httpClient);
+        var client = CreateWorldApiClient(factory);
 
         // Act
         var result = await client.GetTypesPage();
@@ -262,8 +260,7 @@ public class WorldApiClientTests {
         // Arrange
         var payload = GetResourceString("FrontierSharp.Tests.WorldApi.payloads.v2.solarsystems.30012580.json");
         var factory = SubstitutableHttpClientFactory.CreateWithPayload(payload);
-        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
-        var client = new WorldApiClient(httpClient);
+        var client = CreateWorldApiClient(factory);
 
         // Act
         var result = await client.GetSolarSystemById(30012580);
@@ -287,8 +284,7 @@ public class WorldApiClientTests {
         // Arrange
         var payload = GetResourceString("FrontierSharp.Tests.WorldApi.payloads.v2.smartcharacters.0x19957f367b81bd7711d316a451ade0d8fa8cb5bf.json");
         var factory = SubstitutableHttpClientFactory.CreateWithPayload(payload);
-        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
-        var client = new WorldApiClient(httpClient);
+        var client = CreateWorldApiClient(factory);
 
         // Act
         var result = await client.GetSmartCharacterById("0x19957f367b81bd7711d316a451ade0d8fa8cb5bf");
@@ -311,8 +307,7 @@ public class WorldApiClientTests {
         // Arrange
         var payload = GetResourceString("FrontierSharp.Tests.WorldApi.payloads.v2.smartassemblies.75343970651982257052710820829442849942642924970878978184835257992027850797979.json");
         var factory = SubstitutableHttpClientFactory.CreateWithPayload(payload);
-        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
-        var client = new WorldApiClient(httpClient);
+        var client = CreateWorldApiClient(factory);
 
         // Act
         var result = await client.GetSmartAssemblyById(BigInteger.Parse("75343970651982257052710820829442849942642924970878978184835257992027850797979"));
@@ -366,6 +361,12 @@ public class WorldApiClientTests {
         result.Value.Location.X.Should().Be(121834326528);
         result.Value.Location.Y.Should().Be(-5201916416);
         result.Value.Location.Z.Should().Be(241142638592);
+    }
+
+    private WorldApiClient CreateWorldApiClient(IHttpClientFactory factory) {
+        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
+        var client = new WorldApiClient(httpClient);
+        return client;
     }
 
     [Fact]

--- a/src/FrontierSharp.Tests/WorldApi/WorldApiClientTests.cs
+++ b/src/FrontierSharp.Tests/WorldApi/WorldApiClientTests.cs
@@ -55,7 +55,7 @@ public class WorldApiClientTests {
                                       """;
 
     private readonly HybridCache _cache = new FakeHybridCache();
-    private readonly MockLogger<WorldApiClient> _logger = Substitute.For<MockLogger<WorldApiClient>>();
+    private readonly MockLogger<FrontierSharpHttpClient> _logger = Substitute.For<MockLogger<FrontierSharpHttpClient>>();
     private readonly IOptions<FrontierSharpHttpClientOptions> _options = Substitute.For<IOptions<FrontierSharpHttpClientOptions>>();
 
     public WorldApiClientTests() {
@@ -94,7 +94,8 @@ public class WorldApiClientTests {
     public async Task GetTypesPage_ShouldReturnTypes_WhenResponseIsValid() {
         // Arrange
         var factory = SubstitutableHttpClientFactory.CreateWithPayload(ValidResponse);
-        var client = new WorldApiClient(_logger, factory, _cache, _options);
+        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
+        var client = new WorldApiClient(httpClient);
 
         // Act
         var result = await client.GetTypesPage();
@@ -109,7 +110,8 @@ public class WorldApiClientTests {
     public async Task GetTypesPage_ShouldReturnFailure_WhenInnerCallFails() {
         // Arrange
         var factory = SubstitutableHttpClientFactory.CreateInternalServerError();
-        var client = new WorldApiClient(_logger, factory, _cache, _options);
+        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
+        var client = new WorldApiClient(httpClient);
 
         // Act
         var result = await client.GetTypesPage();
@@ -132,7 +134,8 @@ public class WorldApiClientTests {
             return Task.FromResult(msg);
         });
 
-        var client = new WorldApiClient(_logger, factory, _cache, _options);
+        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
+        var client = new WorldApiClient(httpClient);
 
         // Act
         var result = await client.GetAllTypes(1);
@@ -159,7 +162,8 @@ public class WorldApiClientTests {
             return Task.FromResult(msg);
         });
 
-        var client = new WorldApiClient(_logger, factory, _cache, _options);
+        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
+        var client = new WorldApiClient(httpClient);
 
         // Act
         var result = await client.GetAllSolarSystems();
@@ -258,7 +262,8 @@ public class WorldApiClientTests {
         // Arrange
         var payload = GetResourceString("FrontierSharp.Tests.WorldApi.payloads.v2.solarsystems.30012580.json");
         var factory = SubstitutableHttpClientFactory.CreateWithPayload(payload);
-        var client = new WorldApiClient(_logger, factory, _cache, _options);
+        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
+        var client = new WorldApiClient(httpClient);
 
         // Act
         var result = await client.GetSolarSystemById(30012580);
@@ -282,7 +287,8 @@ public class WorldApiClientTests {
         // Arrange
         var payload = GetResourceString("FrontierSharp.Tests.WorldApi.payloads.v2.smartcharacters.0x19957f367b81bd7711d316a451ade0d8fa8cb5bf.json");
         var factory = SubstitutableHttpClientFactory.CreateWithPayload(payload);
-        var client = new WorldApiClient(_logger, factory, _cache, _options);
+        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
+        var client = new WorldApiClient(httpClient);
 
         // Act
         var result = await client.GetSmartCharacterById("0x19957f367b81bd7711d316a451ade0d8fa8cb5bf");
@@ -305,7 +311,8 @@ public class WorldApiClientTests {
         // Arrange
         var payload = GetResourceString("FrontierSharp.Tests.WorldApi.payloads.v2.smartassemblies.75343970651982257052710820829442849942642924970878978184835257992027850797979.json");
         var factory = SubstitutableHttpClientFactory.CreateWithPayload(payload);
-        var client = new WorldApiClient(_logger, factory, _cache, _options);
+        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
+        var client = new WorldApiClient(httpClient);
 
         // Act
         var result = await client.GetSmartAssemblyById(BigInteger.Parse("75343970651982257052710820829442849942642924970878978184835257992027850797979"));
@@ -365,7 +372,8 @@ public class WorldApiClientTests {
     public async Task GetAllTypes_ShouldReturnFailure_WhenPageFails() {
         // Arrange
         var factory = SubstitutableHttpClientFactory.CreateInternalServerError();
-        var client = new WorldApiClient(_logger, factory, _cache, _options);
+        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
+        var client = new WorldApiClient(httpClient);
 
         // Act
         var result = await client.GetAllTypes();
@@ -395,7 +403,8 @@ public class WorldApiClientTests {
                        }
                        """;
         var factory = SubstitutableHttpClientFactory.CreateWithPayload(response);
-        var client = new WorldApiClient(_logger, factory, _cache, _options);
+        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
+        var client = new WorldApiClient(httpClient);
 
         // Act
         var result = await client.GetTypeById(42);
@@ -410,7 +419,8 @@ public class WorldApiClientTests {
     public async Task GetTypeById_ShouldReturnFailure_WhenInnerCallFails() {
         // Arrange
         var factory = SubstitutableHttpClientFactory.CreateInternalServerError();
-        var client = new WorldApiClient(_logger, factory, _cache, _options);
+        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
+        var client = new WorldApiClient(httpClient);
 
         // Act
         var result = await client.GetTypeById(42);
@@ -429,6 +439,7 @@ public class WorldApiClientTests {
             };
             return Task.FromResult(msg);
         });
-        return new WorldApiClient(_logger, factory, _cache, _options);
+        var httpClient = new FrontierSharpHttpClient(_logger, factory, _cache, _options);
+        return new WorldApiClient(httpClient);
     }
 }

--- a/src/FrontierSharp.WorldApi/WorldApiClient.cs
+++ b/src/FrontierSharp.WorldApi/WorldApiClient.cs
@@ -4,27 +4,22 @@ using FrontierSharp.HttpClient;
 using FrontierSharp.WorldApi.Models;
 using FrontierSharp.WorldApi.RequestModel;
 using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace FrontierSharp.WorldApi;
 
-public class WorldApiClient(
-    ILogger<WorldApiClient> logger,
-    IHttpClientFactory httpClientFactory,
-    HybridCache cache,
-    IOptions<FrontierSharpHttpClientOptions> options)
-    : FrontierSharpHttpClient(logger, httpClientFactory, cache, options), IWorldApiClient {
-
+public class WorldApiClient([FromKeyedServices(nameof(WorldApiClient))] IFrontierSharpHttpClient httpClient) : IWorldApiClient {
     public async Task<Result<GameType>> GetTypeById(long id, CancellationToken cancellationToken = default) {
         var requestModel = new GetTypeById { TypeId = id };
-        var result = await Get<GetTypeById, GameType>(requestModel, cancellationToken);
+        var result = await httpClient.Get<GetTypeById, GameType>(requestModel, cancellationToken);
         return result.IsFailed ? Result.Fail(result.Errors) : Result.Ok(result.Value);
     }
 
     public async Task<Result<WorldApiPayload<GameType>>> GetTypesPage(long limit = 100, long offset = 0, CancellationToken cancellationToken = default) {
         var requestModel = new GetListOfTypes { Limit = limit, Offset = offset };
-        var result = await Get<GetListOfTypes, WorldApiPayload<GameType>>(requestModel, cancellationToken);
+        var result = await httpClient.Get<GetListOfTypes, WorldApiPayload<GameType>>(requestModel, cancellationToken);
         return result.IsFailed ? Result.Fail(result.Errors) : Result.Ok(result.Value);
     }
 
@@ -34,7 +29,7 @@ public class WorldApiClient(
 
     public async Task<Result<WorldApiPayload<Fuel>>> GetFuelsPage(long limit = 100, long offset = 0, CancellationToken cancellationToken = default) {
         var requestModel = new GetListOfFuels { Limit = limit, Offset = offset };
-        var result = await Get<GetListOfFuels, WorldApiPayload<Fuel>>(requestModel, cancellationToken);
+        var result = await httpClient.Get<GetListOfFuels, WorldApiPayload<Fuel>>(requestModel, cancellationToken);
         return result.IsFailed ? Result.Fail(result.Errors) : Result.Ok(result.Value);
     }
 
@@ -44,13 +39,13 @@ public class WorldApiClient(
 
     public async Task<Result<SolarSystemDetail>> GetSolarSystemById(long id, CancellationToken cancellationToken = default) {
         var requestModel = new GetSolarSystemById { SolarSystemId = id };
-        var result = await Get<GetSolarSystemById, SolarSystemDetail>(requestModel, cancellationToken);
+        var result = await httpClient.Get<GetSolarSystemById, SolarSystemDetail>(requestModel, cancellationToken);
         return result.IsFailed ? Result.Fail(result.Errors) : Result.Ok(result.Value);
     }
 
     public async Task<Result<WorldApiPayload<SolarSystem>>> GetSolarSystemPage(long limit = 1000, long offset = 0, CancellationToken cancellationToken = default) {
         var requestModel = new GetListOfSolarSystems { Limit = limit, Offset = offset };
-        var result = await Get<GetListOfSolarSystems, WorldApiPayload<SolarSystem>>(requestModel, cancellationToken);
+        var result = await httpClient.Get<GetListOfSolarSystems, WorldApiPayload<SolarSystem>>(requestModel, cancellationToken);
         return result.IsFailed ? Result.Fail(result.Errors) : Result.Ok(result.Value);
     }
 
@@ -60,13 +55,13 @@ public class WorldApiClient(
 
     public async Task<Result<SmartAssemblyDetail>> GetSmartAssemblyById(BigInteger id, CancellationToken cancellationToken = default) {
         var requestModel = new GetSmartAssemblyById { SmartObjectId = id };
-        var result = await Get<GetSmartAssemblyById, SmartAssemblyDetail>(requestModel, cancellationToken);
+        var result = await httpClient.Get<GetSmartAssemblyById, SmartAssemblyDetail>(requestModel, cancellationToken);
         return result.IsFailed ? Result.Fail(result.Errors) : Result.Ok(result.Value);
     }
 
     public async Task<Result<WorldApiPayload<SmartAssemblyWithSolarSystem>>> GetSmartAssemblyPage(long limit = 100, long offset = 0, CancellationToken cancellationToken = default) {
         var requestModel = new GetListOfSmartAssemblies { Limit = limit, Offset = offset };
-        var result = await Get<GetListOfSmartAssemblies, WorldApiPayload<SmartAssemblyWithSolarSystem>>(requestModel, cancellationToken);
+        var result = await httpClient.Get<GetListOfSmartAssemblies, WorldApiPayload<SmartAssemblyWithSolarSystem>>(requestModel, cancellationToken);
         return result.IsFailed ? Result.Fail(result.Errors) : Result.Ok(result.Value);
     }
 
@@ -76,13 +71,13 @@ public class WorldApiClient(
 
     public async Task<Result<SmartCharacterDetail>> GetSmartCharacterById(string address, CancellationToken cancellationToken = default) {
         var requestModel = new GetSmartCharacterById { CharacterAddress = address };
-        var result = await Get<GetSmartCharacterById, SmartCharacterDetail>(requestModel, cancellationToken);
+        var result = await httpClient.Get<GetSmartCharacterById, SmartCharacterDetail>(requestModel, cancellationToken);
         return result.IsFailed ? Result.Fail(result.Errors) : Result.Ok(result.Value);
     }
 
     public async Task<Result<WorldApiPayload<SmartCharacter>>> GetSmartCharacterPage(long limit = 100, long offset = 0, CancellationToken cancellationToken = default) {
         var requestModel = new GetListOfSmartCharacters { Limit = limit, Offset = offset };
-        var result = await Get<GetListOfSmartCharacters, WorldApiPayload<SmartCharacter>>(requestModel, cancellationToken);
+        var result = await httpClient.Get<GetListOfSmartCharacters, WorldApiPayload<SmartCharacter>>(requestModel, cancellationToken);
         return result.IsFailed ? Result.Fail(result.Errors) : Result.Ok(result.Value);
     }
 

--- a/src/FrontierSharp.sln.DotSettings.user
+++ b/src/FrontierSharp.sln.DotSettings.user
@@ -18,6 +18,9 @@
 	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=7020124F_002D9FFC_002D4AC3_002D8F3D_002DAAB8E0240759_002Ff_003AUriBuilder_002Ecs_002Fl_003A_002E_002E_003F_002E_002E_003F_002E_002E_003F_002Econfig_003FJetBrains_003FRider2024_002E3_003Fresharper_002Dhost_003FSourcesCache_003F10821a7c6456595b62433c59889dfe462fca7a3fa6fa981c1dcd3204ff3c210_003FUriBuilder_002Ecs/@EntryIndexedValue">ForceIncluded</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/SweaWarningsMode/@EntryValue">ShowAndRun</s:String>
 	<s:String x:Key="/Default/Environment/Highlighting/HighlightingSourceSnapshotLocation/@EntryValue">/home/scetrov/.cache/JetBrains/Rider2025.1/resharper-host/temp/Rider/vAny/CoverageData/_FrontierSharp.186870716/Snapshot/snapshot.utdcvr</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=79081fe5_002D3d23_002D4c2f_002Da90c_002D4aaf23a3201f/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from Solution" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
+  &lt;Solution /&gt;
+&lt;/SessionState&gt;</s:String>
 	
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=885b98c1_002D1c70_002D4ec4_002Db11c_002Da896ee4fb614/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from Solution" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
   &lt;Solution /&gt;


### PR DESCRIPTION
Switch to injected FrontierSharpHttpClient in `WorldApiClient`, updating method calls and adapting tests accordingly  
- Refactored `WorldApiClient` to accept an `IFrontierSharpHttpClient` via DI instead of inheriting  
- Updated all `.Get<…, …>` calls to use the injected `httpClient`  
- Modified unit tests to instantiate `FrontierSharpHttpClient` and inject it into `WorldApiClient`