### PR TITLE
fix(): fix "Unknown" SmartAssemblyType

### DIFF
--- a/src/FrontierSharp.Tests/WorldApi/payloads/v2/smartassemblies_limit=100_offset=200.json
+++ b/src/FrontierSharp.Tests/WorldApi/payloads/v2/smartassemblies_limit=100_offset=200.json
@@ -2,7 +2,7 @@
   "data": [
     {
       "id": "104032213263817986165936338204246357007418294632504002605694418518017995249676",
-      "type": "Manufacturing",
+      "type": "Unknown",
       "name": "",
       "state": "anchored",
       "solarSystem": {

--- a/src/FrontierSharp.WorldApi/Models/SmartAssembly.cs
+++ b/src/FrontierSharp.WorldApi/Models/SmartAssembly.cs
@@ -9,8 +9,8 @@ public class SmartAssembly {
     public string Id { get; set; } = string.Empty;
 
     [JsonPropertyName("type")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
-    public SmartAssemblyType Type { get; set; } = SmartAssemblyType.NetworkNode;
+    [JsonConverter(typeof(SmartAssemblyTypeConverter))]
+    public SmartAssemblyType Type { get; set; } = SmartAssemblyType.Unknown;
 
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;

--- a/src/FrontierSharp.WorldApi/Models/SmartAssemblyType.cs
+++ b/src/FrontierSharp.WorldApi/Models/SmartAssemblyType.cs
@@ -6,5 +6,6 @@ public enum SmartAssemblyType {
     SmartStorageUnit,
     SmartGate,
     SmartTurret,
-    SmartHangar
+    SmartHangar,
+    Unknown
 }

--- a/src/FrontierSharp.WorldApi/Models/SmartAssemblyTypeConverter.cs
+++ b/src/FrontierSharp.WorldApi/Models/SmartAssemblyTypeConverter.cs
@@ -1,0 +1,29 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace FrontierSharp.WorldApi.Models;
+
+public class SmartAssemblyTypeConverter : JsonConverter<SmartAssemblyType> {
+    public override SmartAssemblyType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
+        switch (reader.TokenType) {
+            case JsonTokenType.String: {
+                var enumText = reader.GetString();
+                if (Enum.TryParse<SmartAssemblyType>(enumText, ignoreCase: true, out var value)) {
+                    return value;
+                }
+
+                break;
+            }
+            case JsonTokenType.Number when reader.TryGetInt32(out int intValue) && Enum.IsDefined(typeof(SmartAssemblyType), intValue):
+                return (SmartAssemblyType)intValue;
+            default:
+                return SmartAssemblyType.Unknown;
+        }
+
+        return SmartAssemblyType.Unknown; // Fallback
+    }
+
+    public override void Write(Utf8JsonWriter writer, SmartAssemblyType value, JsonSerializerOptions options) {
+        writer.WriteStringValue(value.ToString());
+    }
+}

--- a/src/FrontierSharp.WorldApi/Models/SmartAssemblyTypeConverter.cs
+++ b/src/FrontierSharp.WorldApi/Models/SmartAssemblyTypeConverter.cs
@@ -19,6 +19,8 @@ public class SmartAssemblyTypeConverter : JsonConverter<SmartAssemblyType> {
             default:
                 return SmartAssemblyType.Unknown;
         }
+
+        return SmartAssemblyType.Unknown;
     }
 
     public override void Write(Utf8JsonWriter writer, SmartAssemblyType value, JsonSerializerOptions options) {

--- a/src/FrontierSharp.WorldApi/Models/SmartAssemblyTypeConverter.cs
+++ b/src/FrontierSharp.WorldApi/Models/SmartAssemblyTypeConverter.cs
@@ -19,8 +19,6 @@ public class SmartAssemblyTypeConverter : JsonConverter<SmartAssemblyType> {
             default:
                 return SmartAssemblyType.Unknown;
         }
-
-        return SmartAssemblyType.Unknown; // Fallback
     }
 
     public override void Write(Utf8JsonWriter writer, SmartAssemblyType value, JsonSerializerOptions options) {


### PR DESCRIPTION
Fixes handling of unknown `SmartAssemblyType` values during JSON deserialization by implementing a custom converter that gracefully falls back to an "Unknown" enum value instead of failing on unrecognized types.

Key changes:
- Added custom `SmartAssemblyTypeConverter` to handle unknown enum values gracefully
- Added `Unknown` value to the `SmartAssemblyType` enum as a fallback option
- Updated default value from `NetworkNode` to `Unknown` for better semantic accuracy