### PR TITLE
Pin GitHub Actions and update Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # NuGet — version updates
+  # NuGet — main solution/package dependencies.
   - package-ecosystem: "nuget"
     directory: "/src"
     schedule:
@@ -11,44 +11,54 @@ updates:
     open-pull-requests-limit: 10
     target-branch: "main"
     rebase-strategy: "auto"
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "deps"
       include: "scope"
     labels:
       - "dependencies"
       - "nuget"
-    # Cooldown: let new releases stabilize before Dependabot proposes them.
-    # Does NOT delay security updates — those are always immediate.
-    cooldown:
-      semver-major-days: 14
-      semver-minor-days: 5
-      semver-patch-days: 2
     groups:
-      # Batch minor + patch into one PR per week — low risk, easy to review.
-      nuget-minor-patch:
+      nuget-version-updates:
         applies-to: version-updates
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
-      # Keep major bumps separate so they get individual attention.
-      nuget-major:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        update-types:
-          - "major"
-      # Group all security fixes (CVEs, malware advisories) into one PR.
-      # GitHub's Advisory Database — which includes supply-chain malware
-      # detections — drives these alerts automatically when Dependabot
-      # security updates are enabled for the repository.
-      nuget-security:
+      nuget-security-updates:
         applies-to: security-updates
         patterns:
           - "*"
 
-  # GitHub Actions — keep workflow actions up-to-date and patched.
+  # NuGet — example project dependencies.
+  - package-ecosystem: "nuget"
+    directory: "/examples/AssemblyWatcherExample"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    target-branch: "main"
+    rebase-strategy: "auto"
+    cooldown:
+      default-days: 5
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "nuget"
+    groups:
+      nuget-examples-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      nuget-examples-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # GitHub Actions — workflow action dependencies.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -59,6 +69,8 @@ updates:
     open-pull-requests-limit: 10
     target-branch: "main"
     rebase-strategy: "auto"
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -66,16 +78,16 @@ updates:
       - "dependencies"
       - "github-actions"
     groups:
-      github-actions-version:
+      github-actions-version-updates:
         applies-to: version-updates
         patterns:
           - "*"
-      github-actions-security:
+      github-actions-security-updates:
         applies-to: security-updates
         patterns:
           - "*"
 
-  # Docker — keep base images patched.
+  # Docker — command-line image dependencies.
   - package-ecosystem: "docker"
     directory: "/src/FrontierSharp.CommandLine"
     schedule:
@@ -86,6 +98,8 @@ updates:
     open-pull-requests-limit: 10
     target-branch: "main"
     rebase-strategy: "auto"
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -93,28 +107,11 @@ updates:
       - "dependencies"
       - "docker"
     groups:
-      docker-version:
+      docker-version-updates:
         applies-to: version-updates
         patterns:
           - "*"
-      docker-security:
+      docker-security-updates:
         applies-to: security-updates
         patterns:
           - "*"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
-    open-pull-requests-limit: 10
-    commit-message:
-      prefix: "ci"
-      include: "scope"
-    labels:
-      - "dependencies"
-      - "github-actions"
-      - "security"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,17 +17,17 @@ jobs:
     
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: 10.x
 
       - name: Cache NuGet Packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.lock.json', '**/*.csproj') }}
@@ -63,17 +63,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: 10.x
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v4.5.0
+        uses: gittools/actions/gitversion/setup@bc6623af8fc07d5a8903052dd46da33403eec8e8 # v4.5.0
         with:
           versionSpec: '6.7.x'
 
@@ -171,21 +171,21 @@ jobs:
         working-directory: ./src/FrontierSharp.CommandLine/bin/Release/net10.0/win-arm64/publish
 
       - name: Create Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ steps.version_step.outputs.FullSemVer }}
           commit: ${{ github.sha }}
           artifacts: "./src/nupkg/*.nupkg,./src/nupkg/*.snupkg,./src/*.tar.gz,./src/*.zip"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Set lowercase repository name
         id: repo_name
@@ -195,7 +195,7 @@ jobs:
 
       - name: Extract release version
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ghcr.io/${{ steps.repo_name.outputs.repo_lc }}
           tags: |
@@ -205,7 +205,7 @@ jobs:
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ./src/FrontierSharp.CommandLine
           push: true


### PR DESCRIPTION
## Summary
- Pin build-and-test workflow actions to latest-version commit SHAs
- Add Dependabot grouped updates with 5-day cooldowns
- Include GitHub Actions, NuGet, and Docker ecosystems

## Validation
- Verified all workflow action refs are pinned to 40-character SHAs
- Confirmed Dependabot entries include groups and cooldowns