### PR TITLE
Improve OpenSSF Best Practices evidence and address four unmet criteria

### DIFF
--- a/.bestpractices.json
+++ b/.bestpractices.json
@@ -88,9 +88,11 @@
       "evidence_url": "https://github.com/Scetrov/FrontierSharp/commits"
     },
     "repo_interim": {
-      "status": "Unmet",
+      "status": "Met",
       "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
+      "badge_level": "in_progress",
+      "justification": "All development occurs in the main branch via pull requests. Each merge creates an interim version reviewable in the commit history between tagged releases.",
+      "evidence_url": "https://github.com/Scetrov/FrontierSharp/commits/main"
     },
     "repo_distributed": {
       "status": "Met",
@@ -119,10 +121,11 @@
       "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
     },
     "release_notes": {
-      "status": "Unmet",
+      "status": "Met",
       "project_url": "https://www.bestpractices.dev/projects/13670",
       "badge_level": "in_progress",
-      "justification": "No release notes file found."
+      "justification": "Human-readable release notes maintained in CHANGELOG.md covering all tagged releases.",
+      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/CHANGELOG.md"
     },
     "report_tracker": {
       "status": "Met",
@@ -250,9 +253,11 @@
       "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
     },
     "warnings_strict": {
-      "status": "Unmet",
+      "status": "Met",
       "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
+      "badge_level": "in_progress",
+      "justification": "TreatWarningsAsErrors is enabled globally via src/Directory.Build.props. Build produces 0 warnings and 0 errors.",
+      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/src/Directory.Build.props"
     },
     "know_secure_design": {
       "status": "Met",
@@ -364,10 +369,11 @@
       "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
     },
     "dynamic_analysis": {
-      "status": "Unmet",
+      "status": "Met",
       "project_url": "https://www.bestpractices.dev/projects/13670",
       "badge_level": "in_progress",
-      "justification": "Currently in a early release state while game is in Alpha"
+      "justification": "Proven SharpFuzz/AFL++ coverage-guided fuzzing campaigns run in CI for all four parser targets (sui, resindex, pickle, world) with explicit time bounds and sanitized crash artifact retention.",
+      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/.github/workflows/fuzz.yml"
     },
     "dynamic_analysis_unsafe": {
       "status": "N/A",
@@ -375,10 +381,11 @@
       "badge_level": "in_progress"
     },
     "dynamic_analysis_enable_assertions": {
-      "status": "Unmet",
+      "status": "Met",
       "project_url": "https://www.bestpractices.dev/projects/13670",
       "badge_level": "in_progress",
-      "justification": "Currently in a early release state while game is in Alpha"
+      "justification": "Fuzz harness binaries are built in Debug configuration (dotnet publish -c Debug), which enables Debug.Assert assertions. Corpus replay in pull-request CI runs in Release configuration.",
+      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/.github/workflows/fuzz.yml"
     },
     "dynamic_analysis_fixed": {
       "status": "N/A",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,121 @@
+# Changelog
+
+All notable changes to FrontierSharp are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
+
+## [Unreleased]
+
+### Changed
+
+- Improved OpenSSF Scorecard assurance signals: proven SharpFuzz/AFL++ fuzzing workflow, `.bestpractices.json` evidence, and fixed Best Practices badge.
+
+## [1.0.36] - 2026-07-22
+
+### Changed
+
+- Archived the `improve-project-scorecard` open spec change and synced spec updates.
+
+## [1.0.35] - 2026-07-22
+
+### Changed
+
+- Recorded post-merge external verification state for OpenSSF assurance signals.
+
+## [1.0.34] - 2026-07-22
+
+### Added
+
+- Per-target bounded AFL++ fuzzing workflow with SharpFuzz instrumentation.
+- `.bestpractices.json` with 67 answerable OpenSSF Best Practices criteria from public project record.
+
+### Changed
+
+- Fixed Best Practices badge URL and accessible alt text in README.
+
+## [1.0.33] - 2026-07-20
+
+### Added
+
+- OpenSSF Scorecard supply-chain security workflow.
+- Supply-chain workflows and governance documentation.
+
+## [1.0.32] - 2026-07-20
+
+### Changed
+
+- Bumped NuGet dependencies (13 updates).
+- Bumped GitHub Actions dependencies (4 updates).
+
+## [1.0.30] - 2026-07-19
+
+### Added
+
+- Supply-chain security hardening controls: Dependabot, dependency review, and signed commits.
+- Governance documentation and threat model.
+
+## [1.0.29] - 2026-07-13
+
+### Changed
+
+- Bumped NuGet and GitHub Actions dependencies.
+
+## [1.0.25] - 2026-07-06
+
+### Added
+
+- Command-line tool for interacting with World and Sui APIs.
+
+## [1.0.14] - 2026-04-20
+
+### Fixed
+
+- Corrected null-handling in Sui GraphQL client edge cases.
+
+### Changed
+
+- Bumped NuGet minor/patch dependencies.
+
+## [1.0.10] - 2026-04-14
+
+### Added
+
+- Fuzzing test project (`FrontierSharp.Fuzz`) with SharpFuzz/AFL++ integration for parser targets.
+- Deterministic corpus replay for Sui, ResIndex, Pickle, and World parser targets.
+
+## [1.0.9] - 2026-04-14
+
+### Added
+
+- NuGet package publishing workflow for releases.
+
+## [1.0.7] - 2026-04-14
+
+### Added
+
+- Build and test CI workflow.
+- Starmap data module for celestial body mappings.
+
+## [1.0.2] - 2026-03-11
+
+### Added
+
+- World API client for tribes, solar systems, and types.
+
+### Changed
+
+- Bumped FluentResults dependency.
+
+## [1.0.1] - 2026-03-11
+
+### Added
+
+- Sui GraphQL client for character data and killmails.
+- HTTP client abstraction with caching support.
+
+## [1.0.0] - 2026-03-09
+
+### Added
+
+- Initial stable release with World API and Sui GraphQL client libraries.
+- EVE Frontier Cycle 5 data model support.

--- a/docs/openssf-assurance.md
+++ b/docs/openssf-assurance.md
@@ -133,18 +133,47 @@ preserves the public project's truthful status values, and includes
 repository-local evidence URLs for all answerable Met and N/A criteria.
 Unsupported or unknown criteria remain omitted.
 
-## Post-merge external verification — pending
+## Post-merge external verification — 2026-07-21
 
-- **Owner:** maintainer
-- **5.1 — Scorecard:** after the merged fuzz workflow runs, trigger or wait for the
-  next scheduled Scorecard analysis on the default branch, then record:
-  Scorecard version, analysis date, SARIF category, and whether the Fuzzing
-  check still reports "no fuzzer integrations found." The SharpFuzz/AFL++
-  finding is expected to remain unrecognized; the operational control remains
-  valid regardless.
-- **5.2 — Best Practices badge:** after merge, the `.bestpractices.json` will
-  exist at the repository root. Confirm the README badge image resolves to
-  project 13670 and that the public badge status remains `in_progress` or
-  higher.
-- **Exit criterion:** both recordings are added to this file and no fabricated
-  scores are published.
+The PR `improve-project-scorecard` (github.com/Scetrov/FrontierSharp/pull/131)
+has been merged. External services have not yet refreshed against the merged
+commit; all observations below record the pending state without fabricating
+results.
+
+- **Scorecard (5.1):**
+  - Latest recorded analysis: `2026-07-20T16:13:25Z`, commit `89abee3830f9`,
+    Scorecard `v5.3.0` — predates the merge.
+  - Fuzzing alert 11 (`FuzzingID`): `status: dismissed` at
+    `2026-07-21T20:56:18Z`. The alert was dismissed during development
+    because the proven AFL++ integration was documented and the false
+    negative is recognised.
+  - Next scheduled Scorecard analysis will run on the default-branch cron
+    (`17 14 * * 1`, i.e. Monday 2026-07-27 at 14:17 UTC). That analysis
+    will evaluate the merged code. The SharpFuzz/AFL++ finding is expected
+    to remain unrecognised by `v5.3.0`; Scorecard `v5.5.0` adds FsCheck
+    detection but not SharpFuzz, so no change in the Fuzzing signal is
+    expected until a later Scorecard release or FsCheck properties are
+    added.
+  - **Owner:** maintainer — revisit after Monday cron or trigger analysis
+    manually.
+  - **Exit criterion:** record the new Scorecard commit SHA, date, and
+    finding in this evidence file; no fabricated detection claim.
+
+- **Best Practices badge (5.2):**
+  - Current public record at `bestpractices.dev/projects/13670`:
+    `badge_level: in_progress`, `badge_percentage_0: 94`,
+    `updated_at: 2026-07-20T16:05:52.114Z` — pre-merge snapshot.
+  - The root `.bestpractices.json` was committed in the merge but
+    bestpractices.dev does not automatically read repository-local
+    automation files; the maintainer must submit it through the
+    documented automation flow on the project page.
+  - The README badge image already resolves to project 13670, and the
+    public status remains `in_progress` until the maintainer completes
+    that submission.
+  - **Owner:** maintainer — submit `.bestpractices.json` via
+    bestpractices.dev project 13670 automation page.
+  - **Exit criterion:** record the new `updated_at` timestamp and any
+    badge-level change in this file; no fabricated status change.
+
+Both items are recorded as pending with clear owners and exit criteria;
+no external result has been fabricated.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(IsPackable)' != 'false' and '$(OutputType)' != 'Exe'">

--- a/src/FrontierSharp.Tests/SuiClient/SuiGraphQlClientTests.cs
+++ b/src/FrontierSharp.Tests/SuiClient/SuiGraphQlClientTests.cs
@@ -101,6 +101,7 @@ public class SuiGraphQlClientTests {
         _logger.Received().Log(
             LogLevel.Debug,
             Arg.Is<IDictionary<string, object>>(state =>
+                state != null &&
                 state.ContainsKey("Endpoint") &&
                 Equals(state["Endpoint"], "https://test.local/graphql") &&
                 state.ContainsKey("Payload") &&
@@ -198,6 +199,7 @@ public class SuiGraphQlClientTests {
         _logger.Received().Log(
             LogLevel.Debug,
             Arg.Is<IDictionary<string, object>>(state =>
+                state != null &&
                 state.ContainsKey("Endpoint") &&
                 Equals(state["Endpoint"], "https://test.local/graphql") &&
                 state.ContainsKey("Payload") &&

--- a/src/FrontierSharp.Tests/SuiClient/WorldClientTests.cs
+++ b/src/FrontierSharp.Tests/SuiClient/WorldClientTests.cs
@@ -283,6 +283,7 @@ public class WorldClientTests {
         await _graphQlClient.Received(1).QueryAsync<ObjectsQueryData>(
             WorldQueries.GetObjectsByType,
             Arg.Is<Dictionary<string, object?>>(v =>
+                v != null &&
                 v["type"]!.ToString() == $"{PackageAddress}::killmail::Killmail" &&
                 Equals(v["first"], 10) &&
                 Equals(v["after"], "cursor123")),
@@ -313,6 +314,7 @@ public class WorldClientTests {
         await _graphQlClient.Received(1).QueryAsync<ObjectsQueryData>(
             WorldQueries.GetObjectsByType,
             Arg.Is<Dictionary<string, object?>>(v =>
+                v != null &&
                 v["type"]!.ToString() == $"{PackageAddress}::killmail::Killmail"),
             Arg.Any<CancellationToken>());
     }
@@ -331,6 +333,7 @@ public class WorldClientTests {
         await _graphQlClient.Received(1).QueryAsync<ObjectsQueryData>(
             WorldQueries.GetObjectsByType,
             Arg.Is<Dictionary<string, object?>>(v =>
+                v != null &&
                 v["type"]!.ToString() == $"{overridePackage}::killmail::Killmail"),
             Arg.Any<CancellationToken>());
     }
@@ -503,6 +506,7 @@ public class WorldClientTests {
         await _graphQlClient.Received(1).QueryAsync<ObjectsQueryData>(
             WorldQueries.GetObjectsByType,
             Arg.Is<Dictionary<string, object?>>(v =>
+                v != null &&
                 v["type"]!.ToString() == $"{PackageAddress}::character::Character"),
             Arg.Any<CancellationToken>());
     }
@@ -671,6 +675,7 @@ public class WorldClientTests {
         await _graphQlClient.Received(1).QueryAsync<ObjectsQueryData>(
             WorldQueries.GetObjectsByType,
             Arg.Is<Dictionary<string, object?>>(v =>
+                v != null &&
                 v["type"]!.ToString() == $"{PackageAddress}::assembly::Assembly"),
             Arg.Any<CancellationToken>());
     }
@@ -784,6 +789,7 @@ public class WorldClientTests {
         await _graphQlClient.Received().QueryAsync<ObjectsQueryData>(
             WorldQueries.GetObjectsByType,
             Arg.Is<Dictionary<string, object?>>(variables =>
+                variables != null &&
                 variables["type"]!.ToString() == $"{PackageAddress}::assembly::Assembly" &&
                 Equals(variables["first"], 10) &&
                 variables["after"] == null),
@@ -825,6 +831,7 @@ public class WorldClientTests {
         await _graphQlClient.Received(1).QueryAsync<ObjectsQueryData>(
             WorldQueries.GetObjectsByType,
             Arg.Is<Dictionary<string, object?>>(variables =>
+                variables != null &&
                 variables["type"]!.ToString() == $"{PackageAddress}::assembly::Assembly" &&
                 Equals(variables["first"], 25) &&
                 variables["after"] == null),
@@ -858,6 +865,7 @@ public class WorldClientTests {
         await _graphQlClient.Received(1).QueryAsync<ObjectsQueryData>(
             WorldQueries.GetObjectsByType,
             Arg.Is<Dictionary<string, object?>>(variables =>
+                variables != null &&
                 variables["type"]!.ToString() == $"{overridePackage}::assembly::Assembly"),
             Arg.Is<GraphQlQueryOptions?>(queryOptions => queryOptions != null && queryOptions.BypassCache),
             Arg.Any<CancellationToken>());
@@ -896,6 +904,7 @@ public class WorldClientTests {
         _logger.Received().Log(
             LogLevel.Error,
             Arg.Is<IDictionary<string, object>>(state =>
+                state != null &&
                 state.ContainsKey("SubscriptionName") &&
                 Equals(state["SubscriptionName"], "Assembly") &&
                 state.ContainsKey("Errors") &&


### PR DESCRIPTION
## Summary

Addresses four unmet OpenSSF Best Practices criteria and records the post-merge external verification state for PR #131.

## Changes

### New criteria addressed (Unmet → Met)

| Criterion | How |
|-----------|-----|
| `release_notes` | Added `CHANGELOG.md` covering all tagged releases |
| `dynamic_analysis` | Documented proven SharpFuzz/AFL++ fuzzing campaigns in CI |
| `dynamic_analysis_enable_assertions` | Fuzz harnesses built in Debug configuration (assertions enabled) |
| `warnings_strict` | Enabled `TreatWarningsAsErrors` via `src/Directory.Build.props`; fixed 11 CS8602 warnings |

### Additional

| Criterion | How |
|-----------|-----|
| `repo_interim` | Added justification: PR-based review between tagged releases |

### Test fixes

- Fixed 11 `CS8602` warnings (nullable dereference) in NSubstitute `Arg.Is` predicates in `SuiGraphQlClientTests.cs` and `WorldClientTests.cs`

### Evidence

- Updated `.bestpractices.json` with truthful justifications and repository-local evidence URLs for all 5 criteria
- Updated `docs/openssf-assurance.md` with post-merge Scorecard and Best Practices state

## Validation

- Build: 0 warnings, 0 errors (with `TreatWarningsAsErrors` active)
- Tests: 221 passed, 0 failed
- `openspec validate improve-project-scorecard --strict`: passed

## Verification

- All changes preserve existing functionality
- No changes to public API or production behavior
- Post-merge external service verification pending (Scorecard cron Monday, Best Practices maintainer submission)