### PR TITLE
Close remaining Best Practices items

### DIFF
--- a/.bestpractices.json
+++ b/.bestpractices.json
@@ -91,8 +91,8 @@
       "status": "Met",
       "project_url": "https://www.bestpractices.dev/projects/13670",
       "badge_level": "in_progress",
-      "justification": "All development occurs in the main branch via pull requests. Each merge creates an interim version reviewable in the commit history between tagged releases.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/commits/main"
+      "justification": "Every same-repository pull request produces an explicitly marked GitHub pre-release containing evaluation packages for its current commit. The pre-release is replaced on each update and removed when the pull request closes.",
+      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/.github/workflows/prerelease.yml"
     },
     "repo_distributed": {
       "status": "Met",
@@ -124,8 +124,8 @@
       "status": "Met",
       "project_url": "https://www.bestpractices.dev/projects/13670",
       "badge_level": "in_progress",
-      "justification": "Human-readable release notes maintained in CHANGELOG.md covering all tagged releases.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/CHANGELOG.md"
+      "justification": "Stable GitHub Releases use generated release notes, and automation copies each published release's notes into CHANGELOG.md.",
+      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/.github/workflows/sync-release-notes.yml"
     },
     "report_tracker": {
       "status": "Met",

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,9 +45,17 @@ jobs:
         run: dotnet build --no-restore --configuration Release -p:Version=0.0.0
         working-directory: ./src
 
-      - name: Test
-        run: dotnet test --no-build --configuration Release --verbosity normal
+      - name: Test with coverage
+        run: dotnet test --no-build --configuration Release --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./TestResults
         working-directory: ./src
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-${{ github.run_id }}
+          path: src/TestResults/**/coverage.cobertura.xml
+          if-no-files-found: warn
 
       - name: Pack NuGet Package
         run: dotnet pack --no-build --configuration Release --output ./nupkg -p:Version=0.0.0
@@ -56,7 +64,7 @@ jobs:
   publish:
     needs: build-and-test
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]'
     environment: nuget-publish
     env:
       BUILDX_NO_DEFAULT_ATTESTATIONS: 1
@@ -101,9 +109,17 @@ jobs:
         run: dotnet build --no-restore --configuration Release -p:Version=${{ steps.version_step.outputs.FullSemVer }} -p:AssemblyVersion=${{ steps.version_step.outputs.AssemblySemVer }} -p:FileVersion=${{ steps.version_step.outputs.AssemblySemFileVer }}
         working-directory: ./src
 
-      - name: Test
-        run: dotnet test --no-build --configuration Release --verbosity normal
+      - name: Test with coverage
+        run: dotnet test --no-build --configuration Release --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./TestResults
         working-directory: ./src
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-${{ github.run_id }}
+          path: src/TestResults/**/coverage.cobertura.xml
+          if-no-files-found: warn
 
       - name: Pack NuGet Package
         run: dotnet pack --no-build --configuration Release --output ./nupkg -p:Version=${{ steps.version_step.outputs.FullSemVer }} -p:AssemblyVersion=${{ steps.version_step.outputs.AssemblySemVer }} -p:FileVersion=${{ steps.version_step.outputs.AssemblySemFileVer }}
@@ -183,6 +199,7 @@ jobs:
           tag: ${{ steps.version_step.outputs.FullSemVer }}
           commit: ${{ github.sha }}
           artifacts: "./src/nupkg/*.nupkg,./src/nupkg/*.snupkg,./src/*.tar.gz,./src/*.zip"
+          generateReleaseNotes: true
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,142 @@
+name: Pull request pre-release
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  publish-prerelease:
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pull request commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.x
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
+        with:
+          versionSpec: '6.7.x'
+
+      - name: Determine version
+        id: version
+        shell: pwsh
+        run: |
+          $gitVersionJson = dotnet-gitversion "$env:GITHUB_WORKSPACE" /config VersionConfig.yml /output json | Out-String
+          $gitVersion = ($gitVersionJson.TrimStart([char]0xFEFF) | ConvertFrom-Json)
+          "fullSemVer=$($gitVersion.FullSemVer)" >> $env:GITHUB_OUTPUT
+          "assemblySemVer=$($gitVersion.AssemblySemVer)" >> $env:GITHUB_OUTPUT
+          "assemblySemFileVer=$($gitVersion.AssemblySemFileVer)" >> $env:GITHUB_OUTPUT
+
+      - name: Restore dependencies
+        run: dotnet restore --locked-mode
+        working-directory: ./src
+
+      - name: Build
+        run: >-
+          dotnet build --no-restore --configuration Release
+          -p:Version=${{ steps.version.outputs.fullSemVer }}
+          -p:AssemblyVersion=${{ steps.version.outputs.assemblySemVer }}
+          -p:FileVersion=${{ steps.version.outputs.assemblySemFileVer }}
+        working-directory: ./src
+
+      - name: Test with coverage
+        run: >-
+          dotnet test --no-build --configuration Release --verbosity normal
+          --collect:"XPlat Code Coverage" --results-directory ./TestResults
+        working-directory: ./src
+
+      - name: Pack pre-release packages
+        run: >-
+          dotnet pack --no-build --configuration Release --output ./nupkg
+          -p:Version=${{ steps.version.outputs.fullSemVer }}
+          -p:AssemblyVersion=${{ steps.version.outputs.assemblySemVer }}
+          -p:FileVersion=${{ steps.version.outputs.assemblySemFileVer }}
+        working-directory: ./src
+
+      - name: Update pull request pre-release tag
+        env:
+          TAG: pr-${{ github.event.pull_request.number }}
+        run: |
+          git tag --force "$TAG" "$GITHUB_SHA"
+          git push origin "refs/tags/$TAG" --force
+
+      - name: Publish pre-release
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+        with:
+          tag: pr-${{ github.event.pull_request.number }}
+          commit: ${{ github.sha }}
+          name: Pre-release for PR #${{ github.event.pull_request.number }}
+          body: >-
+            Evaluation packages for pull request #${{ github.event.pull_request.number }}.
+            Package version: `${{ steps.version.outputs.fullSemVer }}`.
+            This is not a stable release.
+          prerelease: true
+          allowUpdates: true
+          updateOnlyUnreleased: true
+          replacesArtifacts: true
+          artifacts: ./src/nupkg/*.nupkg,./src/nupkg/*.snupkg
+
+      - name: Mark pull request as a pre-release
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const label = 'pre-release';
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: label });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: label,
+                color: '5319e7',
+                description: 'A GitHub pre-release is available for this pull request.'
+              });
+            }
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
+
+  remove-prerelease:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove pull request pre-release
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const tag = `pr-${context.issue.number}`;
+            try {
+              const release = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
+              await github.rest.repos.deleteRelease({ owner, repo, release_id: release.data.id });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+            try {
+              await github.rest.git.deleteRef({ owner, repo, ref: `tags/${tag}` });
+            } catch (error) {
+              if (error.status !== 422) throw error;
+            }

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           tag: pr-${{ github.event.pull_request.number }}
           commit: ${{ github.event.pull_request.head.sha }}
-          name: Pre-release for PR #${{ github.event.pull_request.number }}
+          name: "Pre-release for PR #${{ github.event.pull_request.number }}"
           body: >-
             Evaluation packages for pull request #${{ github.event.pull_request.number }}.
             Package version: `${{ steps.version.outputs.fullSemVer }}`.

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -77,14 +77,14 @@ jobs:
         env:
           TAG: pr-${{ github.event.pull_request.number }}
         run: |
-          git tag --force "$TAG" "$GITHUB_SHA"
+          git tag --force "$TAG" "${{ github.event.pull_request.head.sha }}"
           git push origin "refs/tags/$TAG" --force
 
       - name: Publish pre-release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: pr-${{ github.event.pull_request.number }}
-          commit: ${{ github.sha }}
+          commit: ${{ github.event.pull_request.head.sha }}
           name: Pre-release for PR #${{ github.event.pull_request.number }}
           body: >-
             Evaluation packages for pull request #${{ github.event.pull_request.number }}.

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -93,7 +93,7 @@ jobs:
           prerelease: true
           allowUpdates: true
           updateOnlyUnreleased: true
-          replacesArtifacts: true
+          removeArtifacts: true
           artifacts: ./src/nupkg/*.nupkg,./src/nupkg/*.snupkg
 
       - name: Mark pull request as a pre-release

--- a/.github/workflows/sync-release-notes.yml
+++ b/.github/workflows/sync-release-notes.yml
@@ -1,0 +1,57 @@
+name: Sync release notes to changelog
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+jobs:
+  sync-changelog:
+    if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add published release notes to changelog
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          PUBLISHED_AT: ${{ github.event.release.published_at }}
+          RELEASE_NOTES: ${{ github.event.release.body }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const path = 'CHANGELOG.md';
+            const tag = process.env.TAG;
+            const date = process.env.PUBLISHED_AT.slice(0, 10);
+            const notes = (process.env.RELEASE_NOTES || 'No release notes were provided.').trim();
+            const heading = `## [${tag}] - ${date}`;
+            const file = await github.rest.repos.getContent({ owner, repo, path, ref: context.payload.repository.default_branch });
+            const changelog = Buffer.from(file.data.content, 'base64').toString('utf8');
+
+            if (changelog.includes(heading)) {
+              core.info(`Changelog already contains ${tag}.`);
+              return;
+            }
+
+            const unreleased = '## [Unreleased]\n';
+            if (!changelog.includes(unreleased)) {
+              core.setFailed('CHANGELOG.md must contain an Unreleased section.');
+              return;
+            }
+
+            const entry = `${heading}\n\n${notes}\n\n`;
+            const updated = changelog.replace(unreleased, `${unreleased}\n${entry}`);
+            await github.rest.repos.createOrUpdateFileContents({
+              owner,
+              repo,
+              path,
+              message: `docs: add release notes for ${tag} [skip ci]`,
+              content: Buffer.from(updated).toString('base64'),
+              sha: file.data.sha,
+              branch: context.payload.repository.default_branch,
+              committer: { name: 'github-actions[bot]', email: '41898282+github-actions[bot]@users.noreply.github.com' },
+              author: { name: 'github-actions[bot]', email: '41898282+github-actions[bot]@users.noreply.github.com' }
+            });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- Contributor guide defining signed-commit, pull-request, unit-test, and coverage expectations.
+- Pull-request GitHub pre-releases with evaluation packages and an explicit `pre-release` label.
+- Automated synchronization of published GitHub Release notes into this changelog.
+- CI coverage collection and report artifacts.
+
 ### Changed
 
 - Improved OpenSSF Scorecard assurance signals: proven SharpFuzz/AFL++ fuzzing workflow, `.bestpractices.json` evidence, and fixed Best Practices badge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to FrontierSharp
+
+Thank you for helping improve FrontierSharp. By contributing, you agree to follow this guide and the project's [security policy](SECURITY.md).
+
+## Before you start
+
+- Discuss substantial changes in an issue before investing significant implementation effort.
+- Report suspected vulnerabilities through the [private reporting channel](SECURITY.md#reporting-a-vulnerability), not in a public issue or pull request.
+- Use a focused branch from `main`; do not commit generated binaries, credentials, or local configuration.
+
+## Development standard
+
+Contributions must:
+
+- keep the build warning-free (`TreatWarningsAsErrors` is enabled);
+- include focused unit tests for new behavior and regressions;
+- maintain or improve relevant code coverage, including error paths; and
+- update public documentation, changelog entries under **Unreleased**, and any affected examples.
+
+Run the same essential checks as CI from the repository root:
+
+```sh
+dotnet restore --locked-mode ./src/FrontierSharp.sln
+dotnet build ./src/FrontierSharp.sln --no-restore --configuration Release
+dotnet test ./src/FrontierSharp.sln --no-build --configuration Release \
+  --collect:"XPlat Code Coverage" --results-directory ./src/TestResults
+```
+
+The coverage reports are written below `src/TestResults`. Review coverage for the code you changed rather than treating a percentage alone as a quality target.
+
+## Commits and pull requests
+
+- Sign every commit with your verified GPG or SSH signing key (`git commit -S`).
+- Use a concise, imperative commit subject. Add a body when the reason for a change is not obvious.
+- Open a pull request against `main` with a clear summary, testing evidence, and linked issue when applicable.
+- Keep the pull request small and reviewable. Respond to CI and review feedback before merge.
+- Do not merge a pull request until required checks pass and it has the required approval under the repository's branch-protection rules.
+
+## Interim builds and releases
+
+For pull requests from branches in this repository, CI publishes a GitHub **pre-release** named for the pull request and applies the `pre-release` label. The release contains packages built from the current pull-request commit and is replaced when the pull request is updated. These builds are for evaluation only; use a stable GitHub Release or NuGet package in production.
+
+After a stable release is published, automation copies its GitHub release notes into [CHANGELOG.md](CHANGELOG.md). Contributors should still add human-readable entries under **Unreleased** so the project history remains clear before release automation runs.

--- a/README.md
+++ b/README.md
@@ -135,12 +135,12 @@ public async Task<ActionResult<Tribe>> GetTribes() {
 
 ## Contributing
 
-Contributions are welcome! For bug reports, feature requests, or questions, please open an issue. For code
-contributions, please create a pull request.
+Contributions are welcome. For bug reports, feature requests, or questions, please open an issue. For code contributions, read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request; it documents required signed commits, tests, coverage, and review standards.
+
+Stable releases are documented in both [GitHub Releases](https://github.com/Scetrov/FrontierSharp/releases) and [CHANGELOG.md](CHANGELOG.md). Pull requests from repository branches receive an explicitly labelled GitHub pre-release for evaluation.
 
 > [!IMPORTANT]
-> If you find a security issue with the solution, I would appreciate it if you followed a responsible disclosure process
-> and contacted me directly or via the GitHub Security Reporting programme.
+> If you find a security issue with the solution, please follow the responsible disclosure process in [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/src/FrontierSharp.Tests/FrontierSharp.Tests.csproj
+++ b/src/FrontierSharp.Tests/FrontierSharp.Tests.csproj
@@ -19,6 +19,10 @@
         <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.8.0"/>
         <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="NSubstitute" Version="6.0.0"/>
         <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
             <PrivateAssets>all</PrivateAssets>

--- a/src/FrontierSharp.Tests/packages.lock.json
+++ b/src/FrontierSharp.Tests/packages.lock.json
@@ -24,6 +24,12 @@
           "Newtonsoft.Json": "13.0.1"
         }
       },
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "lkhqpF8Pu2Y7IiN7OntbsTtdbpR1syMsm2F3IgX6ootA4ffRqWL5jF7XipHuZQTdVuWG/gVAAcf8mjk8Tz0xPg=="
+      },
       "FluentResults": {
         "type": "Direct",
         "requested": "[4.0.0, )",


### PR DESCRIPTION
## Summary
- add contribution requirements, coverage collection, and coverage artifacts
- publish labelled, replaceable GitHub pre-releases for same-repository pull requests
- generate GitHub Release notes and synchronize published stable notes to `CHANGELOG.md`

## Security review
- `dotnet list ./src/FrontierSharp.sln package --vulnerable --include-transitive` reports no vulnerable packages.
- GitHub Dependabot reports **0 open alerts**; the 32 historical alerts are fixed.
- No release-note vulnerability entry is needed at present.

## Validation
- `dotnet restore ./src/FrontierSharp.sln --locked-mode`
- `dotnet test ./src/FrontierSharp.sln --configuration Release --collect:"XPlat Code Coverage" --results-directory ./src/TestResults` (221 passed)
- Parsed all GitHub Actions workflow YAML files