### PR TITLE
fix(ci): scope workflow permissions

### DIFF
--- a/.bestpractices.json
+++ b/.bestpractices.json
@@ -1,448 +1,117 @@
 {
-  "project_id": 13670,
-  "project_name": "FrontierSharp",
   "repo_url": "https://github.com/Scetrov/FrontierSharp",
-  "badge_level": "in_progress",
-  "badge_percentage_0": 94,
-  "badge_percentage_1": 7,
-  "badge_percentage_2": 17,
-  "service_url": "https://www.bestpractices.dev/projects/13670",
-  "generated_at": "2026-07-22T18:29:52.818Z",
-  "generated_from": "public bestpractices.dev JSON export",
-  "criteria": {
-    "sites_https": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Given only https: URLs.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "description_good": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp - About",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "interact": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/issues",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "contribution": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Projects on GitHub by default use issues and pull requests, as encouraged by documentation such as <https://guides.github.com/activities/contributing-to-open-source/>.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "license_location": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Non-trivial license location file in repository: <https://github.com/Scetrov/FrontierSharp/blob/main/LICENSE>.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/LICENSE"
-    },
-    "floss_license": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "The MIT license is approved by the Open Source Initiative (OSI).",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/LICENSE"
-    },
-    "floss_license_osi": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "The MIT license is approved by the Open Source Initiative (OSI).",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/LICENSE"
-    },
-    "documentation_basics": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Some documentation basics file contents found.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "documentation_interface": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/blob/main/docs/README.md",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "repo_public": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Repository on GitHub, which provides public git repositories with URLs.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "repo_track": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Repository on GitHub, which uses git. git can track the changes, who made them, and when they were made.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/commits"
-    },
-    "repo_interim": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Every same-repository pull request produces an explicitly marked GitHub pre-release containing evaluation packages for its current commit. The pre-release is replaced on each update and removed when the pull request closes.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/.github/workflows/prerelease.yml"
-    },
-    "repo_distributed": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Repository on GitHub, which uses git. git is distributed.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "version_unique": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/releases",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/releases"
-    },
-    "version_semver": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/releases"
-    },
-    "version_tags": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "release_notes": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Stable GitHub Releases use generated release notes, and automation copies each published release's notes into CHANGELOG.md.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/.github/workflows/sync-release-notes.yml"
-    },
-    "report_tracker": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/issues",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/issues"
-    },
-    "report_process": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Non-trivial SECURITY[.md] file found file in repository: <https://github.com/Scetrov/FrontierSharp/blob/main/SECURITY.md>. [osps_do_02_01]",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "report_responses": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/issues"
-    },
-    "enhancement_responses": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "There was only two requests, both were responded to.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/issues"
-    },
-    "report_archive": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/issues?q=is%3Aissue%20state%3Aclosed",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/issues"
-    },
-    "vulnerability_report_process": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/security",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/SECURITY.md"
-    },
-    "vulnerability_report_private": {
-      "status": "N/A",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
-    },
-    "vulnerability_report_response": {
-      "status": "N/A",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
-    },
-    "build": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/actions",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "build_common_tools": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/tree/main/.github/workflows",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "build_floss_tools": {
-      "status": "Unmet",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": ".NET Platform is not fully FLOSS"
-    },
-    "test": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "test_invocation": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "dotnet test: https://github.com/Scetrov/FrontierSharp/tree/main/src/FrontierSharp.Tests",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "test_most": {
-      "status": "Unmet",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Coverage not automated."
-    },
-    "test_policy": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp#contributing",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "tests_are_added": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp#contributing",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/commits"
-    },
-    "tests_documented_added": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp#contributing",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "warnings": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/blob/3d299796e5c5abfc617cbe84fe0dc0b41046b720/.github/workflows/build-and-test.yml#L45",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "warnings_fixed": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/actions/workflows/build-and-test.yml",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "warnings_strict": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "TreatWarningsAsErrors is enabled globally via src/Directory.Build.props. Build produces 0 warnings and 0 errors.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/src/Directory.Build.props"
-    },
-    "know_secure_design": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Sole Developer - multiply certified both in .NET and cloud software engineering.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "know_common_errors": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Sole Developer undergoes OWASP Top 10 training annually.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "crypto_published": {
-      "status": "N/A",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
-    },
-    "crypto_call": {
-      "status": "N/A",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
-    },
-    "crypto_floss": {
-      "status": "N/A",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
-    },
-    "crypto_keylength": {
-      "status": "N/A",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
-    },
-    "crypto_working": {
-      "status": "N/A",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
-    },
-    "crypto_pfs": {
-      "status": "N/A",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
-    },
-    "crypto_password_storage": {
-      "status": "N/A",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
-    },
-    "crypto_random": {
-      "status": "N/A",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
-    },
-    "delivery_mitm": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Distribution channels use HTTPS exclusively. [osps_br_03_02]",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "delivery_unsigned": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Distribution channels use HTTPS exclusively.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "vulnerabilities_fixed_60_days": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/security/dependabot",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "vulnerabilities_critical_fixed": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/security/dependabot",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "static_analysis": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/security/code-scanning",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "static_analysis_common_vulnerabilities": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/security/code-scanning",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "static_analysis_fixed": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/security/code-scanning",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "static_analysis_often": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "dynamic_analysis": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Proven SharpFuzz/AFL++ coverage-guided fuzzing campaigns run in CI for all four parser targets (sui, resindex, pickle, world) with explicit time bounds and sanitized crash artifact retention.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/.github/workflows/fuzz.yml"
-    },
-    "dynamic_analysis_unsafe": {
-      "status": "N/A",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
-    },
-    "dynamic_analysis_enable_assertions": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Fuzz harness binaries are built in Debug configuration (dotnet publish -c Debug), which enables Debug.Assert assertions. Corpus replay in pull-request CI runs in Release configuration.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/.github/workflows/fuzz.yml"
-    },
-    "dynamic_analysis_fixed": {
-      "status": "N/A",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
-    },
-    "crypto_weaknesses": {
-      "status": "N/A",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
-    },
-    "test_continuous_integration": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/actions",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/.github/workflows/build-and-test.yml"
-    },
-    "discussion": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "GitHub supports discussions on issues and pull requests.",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/issues"
-    },
-    "no_leaked_credentials": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/security/secret-scanning",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/.gitignore"
-    },
-    "english": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "https://github.com/Scetrov/FrontierSharp/blob/main/docs/README.md",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp/blob/main/README.md"
-    },
-    "achieve_passing": {
-      "status": "Unmet",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
-    },
-    "achieve_silver": {
-      "status": "Unmet",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress"
-    },
-    "maintained": {
-      "status": "Met",
-      "project_url": "https://www.bestpractices.dev/projects/13670",
-      "badge_level": "in_progress",
-      "justification": "Dependabot maintains both security updates, and version bumps (with a 5-day cooldown).",
-      "evidence_url": "https://github.com/Scetrov/FrontierSharp"
-    }
-  },
-  "unknown_criteria_omitted": true,
-  "note": "Repository-local evidence record. Badge status is authoritative only from bestpractices.dev."
+  "sites_https_status": "Met",
+  "sites_https_justification": "Given only https: URLs.",
+  "description_good_status": "Met",
+  "description_good_justification": "https://github.com/Scetrov/FrontierSharp - About",
+  "interact_status": "Met",
+  "interact_justification": "https://github.com/Scetrov/FrontierSharp/issues",
+  "contribution_status": "Met",
+  "contribution_justification": "Projects on GitHub by default use issues and pull requests, as encouraged by documentation such as <https://guides.github.com/activities/contributing-to-open-source/>.",
+  "license_location_status": "Met",
+  "license_location_justification": "Non-trivial license location file in repository: <https://github.com/Scetrov/FrontierSharp/blob/main/LICENSE>.",
+  "floss_license_status": "Met",
+  "floss_license_justification": "The MIT license is approved by the Open Source Initiative (OSI).",
+  "floss_license_osi_status": "Met",
+  "floss_license_osi_justification": "The MIT license is approved by the Open Source Initiative (OSI).",
+  "documentation_basics_status": "Met",
+  "documentation_basics_justification": "Some documentation basics file contents found.",
+  "documentation_interface_status": "Met",
+  "documentation_interface_justification": "https://github.com/Scetrov/FrontierSharp/blob/main/docs/README.md",
+  "repo_public_status": "Met",
+  "repo_public_justification": "Repository on GitHub, which provides public git repositories with URLs.",
+  "repo_track_status": "Met",
+  "repo_track_justification": "Repository on GitHub, which uses git. git can track the changes, who made them, and when they were made.",
+  "repo_interim_status": "Met",
+  "repo_interim_justification": "Every same-repository pull request produces an explicitly marked GitHub pre-release containing evaluation packages for its current commit. The pre-release is replaced on each update and removed when the pull request closes.",
+  "repo_distributed_status": "Met",
+  "repo_distributed_justification": "Repository on GitHub, which uses git. git is distributed.",
+  "version_unique_status": "Met",
+  "version_unique_justification": "https://github.com/Scetrov/FrontierSharp/releases",
+  "version_semver_status": "Met",
+  "version_tags_status": "Met",
+  "release_notes_status": "Met",
+  "release_notes_justification": "Stable GitHub Releases use generated release notes, and automation copies each published release's notes into CHANGELOG.md.",
+  "report_tracker_status": "Met",
+  "report_tracker_justification": "https://github.com/Scetrov/FrontierSharp/issues",
+  "report_process_status": "Met",
+  "report_process_justification": "Non-trivial SECURITY[.md] file found file in repository: <https://github.com/Scetrov/FrontierSharp/blob/main/SECURITY.md>. [osps_do_02_01]",
+  "report_responses_status": "Met",
+  "enhancement_responses_status": "Met",
+  "enhancement_responses_justification": "There was only two requests, both were responded to.",
+  "report_archive_status": "Met",
+  "report_archive_justification": "https://github.com/Scetrov/FrontierSharp/issues?q=is%3Aissue%20state%3Aclosed",
+  "vulnerability_report_process_status": "Met",
+  "vulnerability_report_process_justification": "https://github.com/Scetrov/FrontierSharp/security",
+  "vulnerability_report_private_status": "N/A",
+  "vulnerability_report_response_status": "N/A",
+  "build_status": "Met",
+  "build_justification": "https://github.com/Scetrov/FrontierSharp/actions",
+  "build_common_tools_status": "Met",
+  "build_common_tools_justification": "https://github.com/Scetrov/FrontierSharp/tree/main/.github/workflows",
+  "build_floss_tools_status": "Unmet",
+  "build_floss_tools_justification": ".NET Platform is not fully FLOSS",
+  "test_status": "Met",
+  "test_invocation_status": "Met",
+  "test_invocation_justification": "dotnet test: https://github.com/Scetrov/FrontierSharp/tree/main/src/FrontierSharp.Tests",
+  "test_most_status": "Unmet",
+  "test_most_justification": "Coverage not automated.",
+  "test_policy_status": "Met",
+  "test_policy_justification": "https://github.com/Scetrov/FrontierSharp#contributing",
+  "tests_are_added_status": "Met",
+  "tests_are_added_justification": "https://github.com/Scetrov/FrontierSharp#contributing",
+  "tests_documented_added_status": "Met",
+  "tests_documented_added_justification": "https://github.com/Scetrov/FrontierSharp#contributing",
+  "warnings_status": "Met",
+  "warnings_justification": "https://github.com/Scetrov/FrontierSharp/blob/3d299796e5c5abfc617cbe84fe0dc0b41046b720/.github/workflows/build-and-test.yml#L45",
+  "warnings_fixed_status": "Met",
+  "warnings_fixed_justification": "https://github.com/Scetrov/FrontierSharp/actions/workflows/build-and-test.yml",
+  "warnings_strict_status": "Met",
+  "warnings_strict_justification": "TreatWarningsAsErrors is enabled globally via src/Directory.Build.props. Build produces 0 warnings and 0 errors.",
+  "know_secure_design_status": "Met",
+  "know_secure_design_justification": "Sole Developer - multiply certified both in .NET and cloud software engineering.",
+  "know_common_errors_status": "Met",
+  "know_common_errors_justification": "Sole Developer undergoes OWASP Top 10 training annually.",
+  "crypto_published_status": "N/A",
+  "crypto_call_status": "N/A",
+  "crypto_floss_status": "N/A",
+  "crypto_keylength_status": "N/A",
+  "crypto_working_status": "N/A",
+  "crypto_pfs_status": "N/A",
+  "crypto_password_storage_status": "N/A",
+  "crypto_random_status": "N/A",
+  "delivery_mitm_status": "Met",
+  "delivery_mitm_justification": "Distribution channels use HTTPS exclusively. [osps_br_03_02]",
+  "delivery_unsigned_status": "Met",
+  "delivery_unsigned_justification": "Distribution channels use HTTPS exclusively.",
+  "vulnerabilities_fixed_60_days_status": "Met",
+  "vulnerabilities_fixed_60_days_justification": "https://github.com/Scetrov/FrontierSharp/security/dependabot",
+  "vulnerabilities_critical_fixed_status": "Met",
+  "vulnerabilities_critical_fixed_justification": "https://github.com/Scetrov/FrontierSharp/security/dependabot",
+  "static_analysis_status": "Met",
+  "static_analysis_justification": "https://github.com/Scetrov/FrontierSharp/security/code-scanning",
+  "static_analysis_common_vulnerabilities_status": "Met",
+  "static_analysis_common_vulnerabilities_justification": "https://github.com/Scetrov/FrontierSharp/security/code-scanning",
+  "static_analysis_fixed_status": "Met",
+  "static_analysis_fixed_justification": "https://github.com/Scetrov/FrontierSharp/security/code-scanning",
+  "static_analysis_often_status": "Met",
+  "dynamic_analysis_status": "Met",
+  "dynamic_analysis_justification": "Proven SharpFuzz/AFL++ coverage-guided fuzzing campaigns run in CI for all four parser targets (sui, resindex, pickle, world) with explicit time bounds and sanitized crash artifact retention.",
+  "dynamic_analysis_unsafe_status": "N/A",
+  "dynamic_analysis_enable_assertions_status": "Met",
+  "dynamic_analysis_enable_assertions_justification": "Fuzz harness binaries are built in Debug configuration (dotnet publish -c Debug), which enables Debug.Assert assertions. Corpus replay in pull-request CI runs in Release configuration.",
+  "dynamic_analysis_fixed_status": "N/A",
+  "crypto_weaknesses_status": "N/A",
+  "test_continuous_integration_status": "Met",
+  "test_continuous_integration_justification": "https://github.com/Scetrov/FrontierSharp/actions",
+  "discussion_status": "Met",
+  "discussion_justification": "GitHub supports discussions on issues and pull requests.",
+  "no_leaked_credentials_status": "Met",
+  "no_leaked_credentials_justification": "https://github.com/Scetrov/FrontierSharp/security/secret-scanning",
+  "english_status": "Met",
+  "english_justification": "https://github.com/Scetrov/FrontierSharp/blob/main/docs/README.md",
+  "achieve_passing_status": "Unmet",
+  "achieve_silver_status": "Unmet",
+  "maintained_status": "Met",
+  "maintained_justification": "Dependabot maintains both security updates, and version bumps (with a 5-day cooldown)."
 }

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,11 +11,13 @@ on:
       - closed
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   publish-prerelease:
+    permissions:
+      contents: write
+      pull-requests: write
     if: >-
       github.event.action != 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository
@@ -119,6 +121,8 @@ jobs:
             await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
 
   remove-prerelease:
+    permissions:
+      contents: write
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sync-release-notes.yml
+++ b/.github/workflows/sync-release-notes.yml
@@ -6,10 +6,12 @@ on:
       - published
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   sync-changelog:
+    permissions:
+      contents: write
     if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
     runs-on: ubuntu-latest
     steps:

--- a/docs/openssf-assurance.md
+++ b/docs/openssf-assurance.md
@@ -27,6 +27,18 @@ independent coverage; its possible future detector recognition is not a reason
 to add it. Detection also depends on a released `scorecard-action` embedding
 Scorecard `v5.5.0` or later.
 
+## Token-Permissions residual risk — 2026-07-22
+
+- **Alert:** [#13 TokenPermissionsID](https://github.com/Scetrov/FrontierSharp/security/code-scanning/13), observed open on 2026-07-22T19:37:30Z.
+- **Required scope:** `contents: write` only on `.github/workflows/build-and-test.yml`'s `publish` job; that job also retains its required `packages: write` and `id-token: write` publication scopes.
+- **Trusted trigger boundary:** the job runs only after `build-and-test` succeeds for a `push` to `main`, excludes the `github-actions[bot]` actor, and uses the protected `nuget-publish` environment. It does not run for pull requests or untrusted fork code.
+- **Purpose:** create the GitHub release after publishing the verified packages and release artifacts.
+- **Owner:** repository maintainer.
+- **Validation evidence:** workflow YAML parsed successfully and a manual permission-boundary inspection on 2026-07-22 confirmed that `build-and-test` remains `contents: read`, while all publishing write scopes remain on `publish`.
+- **Exit criterion:** remove this authority when a narrower GitHub release-creation permission or a changed release design makes it unnecessary, or record a fresh Scorecard result that confirms resolution. Until then, alert #13 is an open, justified residual signal—not a resolved alert.
+
+Alerts #14 and #15 are separate open TokenPermissionsID findings pending a fresh Scorecard analysis after the scoped `prerelease.yml` and `sync-release-notes.yml` changes. No TokenPermissionsID alert is claimed resolved without that fresh result.
+
 ## Best Practices baseline — 2026-07-21
 
 - **Project:** [FrontierSharp 13670](https://www.bestpractices.dev/projects/13670)

--- a/openspec/changes/harden-workflow-permissions/.openspec.yaml
+++ b/openspec/changes/harden-workflow-permissions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/harden-workflow-permissions/design.md
+++ b/openspec/changes/harden-workflow-permissions/design.md
@@ -1,0 +1,65 @@
+## Context
+
+Three open high-severity OpenSSF Scorecard Token-Permissions alerts originate in release automation. `prerelease.yml` and `sync-release-notes.yml` grant `contents: write` at workflow scope, allowing jobs that only need reads to inherit write authority. `build-and-test.yml` correctly isolates publishing authority to a `publish` job, but that job needs `contents: write` to create the GitHub release, as well as `packages: write` and `id-token: write` for publication.
+
+The repository currently defaults newly created workflow tokens to write access. The Best Practices project (13670) has truthful local evidence and satisfies the substantive Passing requirements, but its public badge remains `in_progress` until a maintainer submits the evidence and the service reports an authoritative outcome.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make read access the workflow baseline and grant write permissions only to the jobs that perform the corresponding operation.
+- Preserve release publication behavior and its required trust boundary.
+- Make the remaining publish-job Token-Permissions finding auditable rather than treating it as resolved without evidence.
+- Obtain and record an authoritative Best Practices service result without claiming a grade before it exists.
+
+**Non-Goals:**
+- Remove or replace GitHub release creation, GitHub Packages publication, NuGet trusted publishing, or PR pre-release behavior.
+- Chase a Scorecard-perfect result by weakening release controls or introducing a separate credential.
+- Claim that Best Practices has awarded Passing before the public project record says so.
+- Address unrelated Scorecard findings or application-code security concerns.
+
+## Decisions
+
+### Default to read-only and elevate at the job boundary
+
+Each affected workflow will declare a read-only top-level baseline. Jobs that create releases, tags, changelog commits, packages, OIDC tokens, or pull-request labels will declare only their required write scopes. This limits accidental authority inheritance when workflows gain new jobs and confines powerful tokens to narrow execution paths.
+
+**Alternative considered:** retain top-level write permissions and rely on current job conditions. Rejected because it leaves unrelated jobs with authority they do not need and is the direct cause of alerts #14 and #15.
+
+### Retain `contents: write` for the trusted main publishing job
+
+The `publish` job will retain `contents: write` because it creates the GitHub release. It runs only following a successful build on a trusted `main` push and does not execute untrusted fork PR code. `packages: write` and `id-token: write` remain scoped to this job for their existing publication functions.
+
+**Alternative considered:** split release creation into a separate workflow or use another credential solely to remove the alert. Rejected because it adds cross-workflow artifact/credential complexity without reducing the necessary release authority.
+
+### Treat alert #13 as a documented residual signal
+
+Assurance evidence will record the alert number, required permission, trigger boundary, owner, validation evidence, and exit criterion. It will distinguish a necessary, constrained permission from a dismissed vulnerability. A future design may reconsider it if GitHub supports a narrower release-creation permission or release publishing changes.
+
+### Verify Best Practices externally
+
+A maintainer will submit the existing evidence through project 13670's supported Best Practices flow, then record the service timestamp, resulting badge level, and any outstanding criteria. The repository will preserve the real outcome, including an `in_progress` outcome if the service does not award Passing.
+
+**Alternative considered:** update the README or local JSON to show Passing immediately. Rejected because the external project record is authoritative.
+
+## Risks / Trade-offs
+
+- [A write scope is accidentally omitted] → Validate all release, pre-release, changelog, package, and label paths after changing permissions; roll back only the missing scope, at the affected job boundary.
+- [Scorecard continues to flag #13] → Preserve the scoped permission and publish the rationale/evidence; do not weaken controls merely to change scanner output.
+- [Best Practices does not award Passing] → Record the actual result and the specific remaining required criteria rather than altering evidence to force a status.
+- [Repository default setting is changed out of band] → Verify the GitHub Actions default workflow-permissions setting during implementation and record it in assurance evidence.
+
+## Migration Plan
+
+1. Change permissions while preserving the existing workflow triggers and job conditions.
+2. Validate workflow YAML and exercise or inspect the affected release paths before relying on production release automation.
+3. Set and verify the repository's read-only default workflow-token setting.
+4. Submit Best Practices evidence, wait for the authoritative result, and update assurance documentation.
+5. Trigger or await a fresh Scorecard analysis; record closed and remaining alerts.
+
+Rollback consists of restoring the previous workflow permission declaration only for an affected automation failure, then narrowing the restored scope after the missing permission is identified. No application data or public API migration is required.
+
+## Open Questions
+
+- Which supported Best Practices submission method/account is available to the maintainer, and does it produce a Passing badge immediately after review?
+- Does the next Scorecard version recognize the justified release-creation permission, or will #13 remain a documented residual alert?

--- a/openspec/changes/harden-workflow-permissions/proposal.md
+++ b/openspec/changes/harden-workflow-permissions/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+OpenSSF Scorecard reports three high-severity Token-Permissions findings because trusted release automation grants broad workflow-level write access or retains a necessary release write permission without an explicit residual-risk record. The OpenSSF Best Practices project is still `in_progress` despite meeting the substantive Passing requirements, because its prepared evidence has not been submitted and externally verified.
+
+## What Changes
+
+- Restrict `GITHUB_TOKEN` permissions to the specific jobs that need release, tag, changelog, package, identity-token, or pull-request write access.
+- Preserve the main-branch publishing job's required `contents: write` permission for GitHub release creation, while documenting its trusted-trigger boundary, justification, owner, and exit criteria as a residual Scorecard signal.
+- Establish repository-level read-only default workflow permissions as defense in depth.
+- Submit the existing truthful Best Practices evidence to project 13670, verify the actual resulting badge status, and record the external result without fabricating a grade.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `repository-security-governance`: Define least-privilege workflow permission boundaries, handling of justified Scorecard token-permission findings, and externally verified Best Practices badge progress.
+
+## Impact
+
+- Affected GitHub Actions workflows: `.github/workflows/prerelease.yml`, `.github/workflows/sync-release-notes.yml`, and `.github/workflows/build-and-test.yml`.
+- Affected repository configuration: GitHub Actions default workflow permissions.
+- Affected assurance evidence: `docs/openssf-assurance.md` and the Best Practices project at `bestpractices.dev/projects/13670`.
+- No public application API, package behavior, or new runtime dependency changes.

--- a/openspec/changes/harden-workflow-permissions/specs/repository-security-governance/spec.md
+++ b/openspec/changes/harden-workflow-permissions/specs/repository-security-governance/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Automation write authority is least-privilege
+GitHub Actions workflows SHALL use a read-only workflow-level permission baseline. A job SHALL declare a write permission only when that job performs the corresponding repository, release, package, identity-token, or pull-request operation, and the declaration SHALL contain no unrelated write scopes.
+
+#### Scenario: A workflow includes both read-only and release operations
+- **WHEN** a workflow contains a job that reads source code and a different job that creates a release, tag, changelog commit, package, or pull-request label
+- **THEN** only the job that performs each write operation receives its corresponding write permission
+
+#### Scenario: A new job is added to an affected workflow
+- **WHEN** a maintainer adds a job without an explicit permissions declaration
+- **THEN** the job receives only the workflow's read-only baseline and no inherited write authority
+
+### Requirement: Necessary publishing authority is an auditable residual risk
+When trusted main-branch publishing requires `contents: write` to create a GitHub release, the repository SHALL keep that authority isolated to the publishing job and SHALL record its alert identifier, purpose, trigger boundary, owner, validation evidence, and exit criterion in assurance evidence. The record MUST NOT characterize the alert as resolved unless the permission is removed or a fresh scanner result confirms resolution.
+
+#### Scenario: Main publishing creates a GitHub release
+- **WHEN** the trusted publishing job creates the project's GitHub release after a successful main-branch build
+- **THEN** it receives `contents: write` only at that job boundary and retains only the other write scopes required for its existing publication operations
+
+#### Scenario: Scorecard continues to flag the publishing permission
+- **WHEN** a fresh Scorecard analysis reports the Token-Permissions alert for the scoped publishing job
+- **THEN** assurance evidence identifies it as a justified residual signal with an owner and exit criterion rather than falsely claiming it is fixed
+
+### Requirement: Best Practices badge submission is externally verified
+The maintainer SHALL submit truthful repository evidence through the supported Best Practices flow for project 13670 and SHALL record the resulting service timestamp, badge level, and any unmet required criteria. The repository MUST NOT claim a Passing badge until bestpractices.dev reports it.
+
+#### Scenario: Best Practices awards Passing
+- **WHEN** bestpractices.dev reports a Passing badge for project 13670 after evidence submission
+- **THEN** assurance evidence records the reported timestamp and badge level, and the README badge continues to resolve to that project
+
+#### Scenario: Best Practices remains in progress
+- **WHEN** bestpractices.dev does not award Passing after evidence submission
+- **THEN** assurance evidence records the actual `in_progress` result and the outstanding required criteria without modifying repository claims to imply a Passing grade

--- a/openspec/changes/harden-workflow-permissions/tasks.md
+++ b/openspec/changes/harden-workflow-permissions/tasks.md
@@ -1,0 +1,18 @@
+## 1. Constrain workflow authority
+
+- [x] 1.1 Set a read-only top-level permissions baseline in `prerelease.yml`; grant `contents: write` and `pull-requests: write` only to the pre-release publishing job and `contents: write` only to the cleanup job.
+- [x] 1.2 Set a read-only top-level permissions baseline in `sync-release-notes.yml`; grant `contents: write` only to the changelog synchronization job.
+- [x] 1.3 Confirm `build-and-test.yml` keeps all existing publishing write scopes exclusively on its trusted `publish` job and does not add write authority to build-and-test jobs.
+- [x] 1.4 Configure and verify the repository GitHub Actions default workflow token permission as read-only.
+
+## 2. Validate release behavior and assurance evidence
+
+- [x] 2.1 Validate workflow syntax and inspect the affected jobs to confirm each release, tag, changelog, package, OIDC, and PR-label operation retains exactly its required permission.
+- [x] 2.2 Update `docs/openssf-assurance.md` with alert #13's required scope, trusted trigger boundary, owner, validation evidence, and exit criterion; distinguish it from resolved alerts.
+- [ ] 2.3 Trigger or await a fresh Scorecard analysis and record the resulting status of alerts #13, #14, and #15 without claiming an unobserved result.
+
+## 3. Verify the Best Practices outcome
+
+- [ ] 3.1 Submit the existing truthful `.bestpractices.json` evidence through the supported Best Practices flow for project 13670.
+- [ ] 3.2 Retrieve the public project record after processing and record its timestamp, badge level, and any remaining required criteria in assurance evidence.
+- [ ] 3.3 Verify the README Best Practices badge continues to resolve to project 13670 and reflects the service-reported status.


### PR DESCRIPTION
## Summary
- establish read-only workflow defaults and scope write authority to release jobs
- document the remaining publish-job permission as a Scorecard residual risk
- add the OpenSpec change artifacts and completed validation tasks

## Validation
- YAML parse validation for all affected workflows
- manual permission-boundary inspection
- verified repository Actions default token permission is `read`